### PR TITLE
Adjust temperature limits and margins

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -350,12 +350,12 @@
 // When temperature exceeds max temp, your heater will be switched off.
 // This feature exists to protect your hotend from overheating accidentally, but *NOT* from thermistor short/failure!
 // You should use MINTEMP for thermistor short/failure protection.
-#define HEATER_0_MAXTEMP 260
+#define HEATER_0_MAXTEMP 285
 #define HEATER_1_MAXTEMP 275
 #define HEATER_2_MAXTEMP 275
 #define HEATER_3_MAXTEMP 275
 #define HEATER_4_MAXTEMP 275
-#define BED_MAXTEMP 120
+#define BED_MAXTEMP 135
 
 //===========================================================================
 //============================= PID Settings ================================

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -48,7 +48,7 @@
    * here we define this default string as the date where the latest release
    * version was tagged.
    */
-  #define STRING_DISTRIBUTION_DATE "2019-02-06"
+  #define STRING_DISTRIBUTION_DATE "2019-02-11"
 
   /**
    * Required minimum Configuration.h and Configuration_adv.h file versions.

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -308,7 +308,7 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
       return;
     }
 
-    if (target > GHV(BED_MAXTEMP, maxttemp[hotend]) - 15) {
+    if (target > GHV(BED_MAXTEMP, maxttemp[hotend]) - 10) {
       SERIAL_ECHOLNPGM(MSG_PID_TEMP_TOO_HIGH);
       return;
     }

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -414,7 +414,7 @@ class Temperature {
       #if ENABLED(AUTO_POWER_CONTROL)
         powerManager.power_on();
       #endif
-      target_temperature[HOTEND_INDEX] = MIN(celsius, maxttemp[HOTEND_INDEX] - 15);
+      target_temperature[HOTEND_INDEX] = MIN(celsius, maxttemp[HOTEND_INDEX] - 10);
       #if WATCH_HOTENDS
         start_watching_heater(HOTEND_INDEX);
       #endif
@@ -449,7 +449,7 @@ class Temperature {
         #endif
         target_temperature_bed =
           #ifdef BED_MAXTEMP
-            MIN(celsius, BED_MAXTEMP - 15)
+            MIN(celsius, BED_MAXTEMP - 10)
           #else
             celsius
           #endif


### PR DESCRIPTION
Lowering the safety margin of MAXTEMP to 10°C and raising MAXTEMP to 285/135.

Resulting in a limit of 275°C for the hotend and 125°C for the heatbed.

Referencing #23