### PR TITLE
Tweak M600 display resume

### DIFF
--- a/Marlin/AnycubicTFT.cpp
+++ b/Marlin/AnycubicTFT.cpp
@@ -264,13 +264,14 @@ void AnycubicTFTClass::FilamentChangeResume(){
         HOTEND_LOOP() thermalManager.reset_heater_idle_timer(e); // resume heating if timed out
         wait_for_heatup = false;
         wait_for_user = false; // remove waiting flags
-        // TFTstate=ANYCUBIC_TFT_STATE_SDPRINT;
+        card.startFileprint(); // resume with proper progress state
 #ifdef ANYCUBIC_TFT_DEBUG
         SERIAL_ECHOLNPGM("DEBUG: M108 Resume called");
 #endif
 }
 
 void AnycubicTFTClass::FilamentChangePause(){
+        PausedByFilamentChange=true;
         enqueue_and_echo_commands_P(PSTR("M600"));
         TFTstate=ANYCUBIC_TFT_STATE_SDPAUSE_REQ; // set TFT state to paused
 #ifdef ANYCUBIC_TFT_DEBUG
@@ -329,7 +330,6 @@ void AnycubicTFTClass::HandleSpecialMenu()
                 enqueue_and_echo_commands_P(PSTR("G91\nG1 Z-0.1\nG90"));
         } else if (strcmp(SelectedDirectory, "<filamentchange pause>")==0) {
                 SERIAL_PROTOCOLLNPGM("Special Menu: FilamentChange Pause");
-                PausedByFilamentChange=true;
                 FilamentChangePause();
         } else if (strcmp(SelectedDirectory, "<filamentchange resume>")==0) {
                 SERIAL_PROTOCOLLNPGM("Special Menu: FilamentChange Resume");

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8508,7 +8508,7 @@ inline void gcode_M109() {
     #ifdef ANYCUBIC_TFT_MODEL
       AnycubicTFT.CommandScan();
     #endif
-    
+
     #if TEMP_RESIDENCY_TIME > 0
 
       const float temp_diff = ABS(target_temp - temp);
@@ -8547,11 +8547,11 @@ inline void gcode_M109() {
   #ifdef ANYCUBIC_TFT_MODEL
   AnycubicTFT.HeatingDone();
   #endif
-  
+
   #if DISABLED(BUSY_WHILE_HEATING)
     KEEPALIVE_STATE(IN_HANDLER);
   #endif
-  
+
   // flush the serial buffer after heating to prevent lockup by m105
   SERIAL_FLUSH();
 
@@ -8665,11 +8665,11 @@ inline void gcode_M109() {
           }
         }
       #endif
-      
+
       #ifdef ANYCUBIC_TFT_MODEL
       AnycubicTFT.CommandScan();
       #endif
-      
+
       #if TEMP_BED_RESIDENCY_TIME > 0
 
         const float temp_diff = ABS(target_temp - temp);
@@ -8697,16 +8697,16 @@ inline void gcode_M109() {
       }
 
     } while (wait_for_heatup && TEMP_BED_CONDITIONS);
-    
+
     #ifdef ANYCUBIC_TFT_MODEL
     AnycubicTFT.BedHeatingDone();
     #endif
-    
+
     if (wait_for_heatup) lcd_reset_status();
     #if DISABLED(BUSY_WHILE_HEATING)
       KEEPALIVE_STATE(IN_HANDLER);
     #endif
-    
+
      // flush the serial buffer after heating to prevent lockup by m105
      SERIAL_FLUSH();
   }
@@ -8904,7 +8904,7 @@ inline void gcode_M111() {
     #if ENABLED(ULTIPANEL)
       lcd_reset_status();
     #endif
-    
+
     #ifdef ANYCUBIC_TFT_MODEL
     AnycubicTFT.CommandScan();
     #endif
@@ -8940,7 +8940,7 @@ inline void gcode_M81() {
   #if ENABLED(ULTIPANEL)
     LCD_MESSAGEPGM(MACHINE_NAME " " MSG_OFF ".");
   #endif
-  
+
   #ifdef ANYCUBIC_TFT_MODEL
   AnycubicTFT.CommandScan();
   #endif
@@ -10992,6 +10992,23 @@ inline void gcode_M502() {
    *  Default values are used for omitted arguments.
    */
   inline void gcode_M600() {
+
+    #ifdef SDSUPPORT
+      if (card.sdprinting) { // are we printing from sd?
+        #ifdef ANYCUBIC_TFT_DEBUG
+            SERIAL_ECHOLNPGM("DEBUG: Enter M600 TFTstate routine");
+        #endif
+        AnycubicTFT.TFTstate=ANYCUBIC_TFT_STATE_SDPAUSE_REQ; // enter correct display state to show resume button
+        #ifdef ANYCUBIC_TFT_DEBUG
+            SERIAL_ECHOLNPGM("DEBUG: Set TFTstate to SDPAUSE_REQ");
+        #endif
+        AnycubicTFT.PausedByFilamentChange=true; // set flag to ensure correct resume routine gets executed
+        #ifdef ANYCUBIC_TFT_DEBUG
+            SERIAL_ECHOLNPGM("DEBUG: Set filament change flag");
+        #endif
+      }
+    #endif
+
     point_t park_point = NOZZLE_PARK_POINT;
 
     if (get_target_extruder_from_command(600)) return;
@@ -11054,19 +11071,6 @@ inline void gcode_M502() {
     const bool job_running = print_job_timer.isRunning();
 
     if (pause_print(retract, park_point, unload_length, true)) {
-      #ifdef SDSUPPORT
-        #ifdef ANYCUBIC_TFT_DEBUG
-            SERIAL_ECHOLNPGM("DEBUG: Enter TFTstate routine");
-        #endif
-        AnycubicTFT.TFTstate=ANYCUBIC_TFT_STATE_SDPAUSE_REQ; // enter correct display state to show resume button
-        #ifdef ANYCUBIC_TFT_DEBUG
-            SERIAL_ECHOLNPGM("DEBUG: Set TFTState to SDPAUSE_REQ");
-        #endif
-        AnycubicTFT.PausedByFilamentChange=true; // set flag to ensure correct resume routine gets executed
-        #ifdef ANYCUBIC_TFT_DEBUG
-            SERIAL_ECHOLNPGM("DEBUG: Set filament change flag");
-        #endif
-      #endif
       wait_for_filament_reload(beep_count);
       resume_print(slow_load_length, fast_load_length, ADVANCED_PAUSE_PURGE_LENGTH, beep_count);
     }
@@ -14753,7 +14757,7 @@ void manage_inactivity(const bool ignore_stepper_queue/*=false*/) {
   #if ENABLED(FILAMENT_RUNOUT_SENSOR)
     runout.run();
   #endif
-  
+
   #if ENABLED(ANYCUBIC_TFT_MODEL) && ENABLED(ANYCUBIC_FILAMENT_RUNOUT_SENSOR)
   AnycubicTFT.FilamentRunout();
   #endif
@@ -14961,7 +14965,7 @@ void idle(
 #ifdef ANYCUBIC_TFT_MODEL
   AnycubicTFT.CommandScan();
 #endif
-  
+
   lcd_update();
 
   host_keepalive();
@@ -15018,7 +15022,7 @@ void kill(const char* lcd_msg) {
   #else
     UNUSED(lcd_msg);
   #endif
-  
+
   #ifdef ANYCUBIC_TFT_MODEL
     // Kill AnycubicTFT
     AnycubicTFT.KillTFT();
@@ -15113,7 +15117,7 @@ void setup() {
   MYSERIAL0.begin(BAUDRATE);
   SERIAL_PROTOCOLLNPGM("start");
   SERIAL_ECHO_START();
-  
+
   #ifdef ANYCUBIC_TFT_MODEL
     // Setup AnycubicTFT
     AnycubicTFT.Setup();
@@ -15139,7 +15143,6 @@ void setup() {
   SERIAL_ECHOPGM(MSG_MARLIN);
   SERIAL_CHAR(' ');
   SERIAL_ECHOLNPGM(SHORT_BUILD_VERSION);
-  SERIAL_CHAR(' ');
   SERIAL_ECHOPGM(MSG_MARLIN_AI3M);
   SERIAL_CHAR(' ');
   SERIAL_ECHOLNPGM(CUSTOM_BUILD_VERSION);

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -41,7 +41,7 @@
    * Defines the version of the Marlin-AI3M build. Not to be confused with
    * Marlin's own build number, e.g. 1.1.9.
    */
-  #define CUSTOM_BUILD_VERSION "v1.4.1"
+  #define CUSTOM_BUILD_VERSION "v1.4.2"
 
   /**
    * Verbose version identifier which should contain a reference to the location
@@ -54,7 +54,7 @@
    * here we define this default string as the date where the latest release
    * version was tagged.
    */
-  #define STRING_DISTRIBUTION_DATE "2019-02-23"
+  #define STRING_DISTRIBUTION_DATE "2019-02-24"
 
   /**
    * Required minimum Configuration.h and Configuration_adv.h file versions.


### PR DESCRIPTION
- Add startFileprint(); call to M108 display routine to fix progress and ensure "printing done" gets shown
- Add SD printing check in marlin_main.cpp M600 routine to skip TFTstate if not necessary (e.g. USB printing)
- Move routine to the top again to ensure immediate execution